### PR TITLE
Adds Ruff as formatter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,27 @@ on:
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+    
+    - name: Install dependencies
+      run: |
+        uv sync --all-extras
+    
+    - name: Check code formatting with ruff
+      run: |
+        uv run ruff format --check
+    
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -25,10 +46,6 @@ jobs:
     - name: Install dependencies
       run: |
         uv sync --all-extras
-    
-    - name: Check code formatting with ruff
-      run: |
-        uv run ruff format --check
     
     - name: Run tests
       run: |

--- a/tests/test_content_processing.py
+++ b/tests/test_content_processing.py
@@ -181,9 +181,7 @@ class TestViewProcessing:
     @pytest.mark.asyncio
     async def test_process_all_views_parallel_auto_load_only(self):
         """Test that only auto-load views are processed initially."""
-        with patch.object(
-            self.app, "_process_single_view", new_callable=AsyncMock
-        ):
+        with patch.object(self.app, "_process_single_view", new_callable=AsyncMock):
             # Mock asyncio.create_task to track what gets created
             created_tasks = []
             original_create_task = asyncio.create_task

--- a/tests/test_scroll_management.py
+++ b/tests/test_scroll_management.py
@@ -72,9 +72,7 @@ class TestScrollManager:
         state = self.scroll_manager._capture_scroll_state(self.mock_content_widget)
 
         assert state["scroll_y"] == 0
-        assert (
-            state["is_at_bottom"]
-        )  # Considered at bottom when no scroll needed
+        assert state["is_at_bottom"]  # Considered at bottom when no scroll needed
 
     def test_restore_scroll_if_needed_at_bottom(self):
         """Test that scroll is not restored when user was at bottom."""


### PR DESCRIPTION
We now have a check that fails if the code isn't formatted, will do the linter later after the code passes 