### PR TITLE
chore: Adding Nox, Coverage, and ruff configs to pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 wheels/
 *.egg-info
 .env
+.coverage
+**/htmlcov
 
 # Virtual environments
 .venv
+.nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import nox
+
+PYTHON_VERSIONS: list[str] = ["3.11", "3.12", "3.13"]
+
+
+@nox.session(venv_backend="uv", tags=["fix"])
+def coverage(session: nox.Session) -> None:
+    """Run tests with coverage reporting."""
+    session.install("coverage[toml]", "pytest", "pytest-cov", "pytest-asyncio")
+    session.install("-e", ".")
+
+    session.run(
+        "pytest",
+        "--cov=src",
+        "--cov-report=term-missing",
+        "--cov-report=html",
+        "--cov-config=pyproject.toml",
+    )
+
+    session.log("Coverage HTML report generated in htmlcov/")
+
+
+@nox.session(venv_backend="uv", tags=["lint"])
+def ruff_check(session: nox.Session) -> None:
+    """Run ruff linting and formatting checks (CI-friendly, no changes)."""
+    session.install("ruff")
+    session.run(
+        "ruff",
+        "check",
+        ".",
+        "--config",
+        "pyproject.toml",
+    )
+    session.run(
+        "ruff",
+        "format",
+        ".",
+        "--check",
+        "--config",
+        "pyproject.toml",
+    )
+
+
+@nox.session(venv_backend="uv", tags=["lint", "fix"])
+def ruff_check_fix(session: nox.Session) -> None:
+    """Run ruff linting and formatting but with a fix attempt (development)."""
+    session.install("ruff")
+    session.run(
+        "ruff",
+        "check",
+        ".",
+        "--fix",
+        "--config",
+        "pyproject.toml",
+    )
+    session.run(
+        "ruff",
+        "check",
+        ".",
+        "--config",
+        "pyproject.toml",
+    )
+    session.run(
+        "ruff",
+        "format",
+        ".",
+        "--check",
+        "--config",
+        "pyproject.toml",
+    )
+
+
+@nox.session(venv_backend="uv", tags=["lint", "fix"])
+def ruff_fix(session: nox.Session) -> None:
+    """Run ruff linting and formatting with auto-fix (development)."""
+    session.install("ruff")
+    session.run(
+        "ruff",
+        "check",
+        ".",
+        "--fix",
+        "--config",
+        "pyproject.toml",
+    )
+    session.run(
+        "ruff",
+        "format",
+        ".",
+        "--config",
+        "pyproject.toml",
+    )
+
+
+@nox.session(python=PYTHON_VERSIONS, venv_backend="uv")
+def all_versions(session: nox.Session) -> None:
+    """Run the unit test suite."""
+    session.install("-e", ".")
+    session.install("pytest", "pytest-asyncio")
+    session.run("pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,59 @@ build-backend = "hatchling.build"
 testpaths = ["tests"]
 pythonpath = ["src"]
 addopts = "-v"
+
+[tool.ruff]
+# Basic config for Ruff
+line-length = 88
+select = [
+    "E",  # Errors
+    "F",  # Fatal errors
+    "I",  # Informational messages
+    "N",  # Non-fatal errors
+    "T",  # Type annotations
+    "W",  # Warnings
+]
+ignore = [
+    "E501",  # Line too long
+    "F401",  # Module imported but unused
+    "F403",  # 'from module import *' used; unable to detect undefined names
+    "F405",  # Name may be undefined, or defined from star imports: module
+]
+
+[tool.coverage.run]
+branch = true
+parallel = true
+source = [
+    "src/"
+]
+
+[tool.coverage.paths]
+equivalent = [
+    "src/",
+    ".venv/lib/*/site-packages/",
+    ".venvs/*/lib/*/site-packages/",
+]
+
+[tool.coverage.report]
+precision = 2
+omit = [
+    "src/*/__init__.py",
+    "src/*/__main__.py",
+    "tests/__init__.py",
+]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING",
+]
+
+[tool.coverage.json]
+output = "htmlcov/coverage.json"
+
+[tool.coverage.html]
+directory = "htmlcov"
+
+[dependency-groups]
+dev = [
+    "nox>=2025.5.1",
+    "pytest-cov>=6.2.1",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,19 +64,15 @@ pythonpath = ["src"]
 addopts = "-v"
 
 [tool.ruff]
-# Basic config for Ruff
+# Basic config for Ruff, feel free to adjust as needed
 line-length = 88
 select = [
-    "E",  # Errors
-    "F",  # Fatal errors
-    "I",  # Informational messages
-    "N",  # Non-fatal errors
-    "T",  # Type annotations
-    "W",  # Warnings
+    "E",  # pycodestyle errors (PEP 8 violations)
+    "F",  # Pyflakes (unused imports, undefined names, etc.)
+    "N",  # pep8-naming (naming convention violations)
 ]
 ignore = [
     "E501",  # Line too long
-    "F401",  # Module imported but unused
     "F403",  # 'from module import *' used; unable to detect undefined names
     "F405",  # Name may be undefined, or defined from star imports: module
 ]


### PR DESCRIPTION
I swear this is the last one for today! Hope it isn't too forward but I added `nox` to the dependencies along with a `noxfile` so you can do `nox -s ruff_check` to run ruff. I've added a basic config to `pyproject.toml` that should be roughly in line with defaults. 

You should be able to use this with Github Actions. `nox -s all_versions` will allow you to do pytest against all versions locally as well as on Github Actions if you want.

`nox -s coverage` will generate a coverage report.

### Development Workflow Enhancements:
* **Nox Sessions for Testing and Linting**: Added multiple Nox sessions (`coverage`, `ruff_check`, `ruff_check_fix`, `ruff_fix`, and `all_versions`) to streamline testing, linting, and formatting tasks across Python versions. These sessions include support for coverage reporting and auto-fixing lint issues. (`noxfile.py`, [noxfile.pyR1-R101](diffhunk://#diff-f7a16a65f061822bcc73b8296f4dc837353d379d8d9cc5307982cb6941442835R1-R101))

### Tool Configuration:
* **Ruff Configuration**: Added a `[tool.ruff]` section in `pyproject.toml` to configure linting rules, including selected error categories and ignored rules. (`pyproject.toml`, [pyproject.tomlR65-R120](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R65-R120))
* **Coverage Configuration**: Added `[tool.coverage.*]` sections in `pyproject.toml` to enable branch coverage, parallel execution, and detailed reporting, including paths equivalence and exclusions for specific files and lines. (`pyproject.toml`, [pyproject.tomlR65-R120](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R65-R120))
