### PR TITLE
better auth error messages

### DIFF
--- a/src/spegel/views.py
+++ b/src/spegel/views.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import List
 
 from .config import View
-from .llm import LLMClient, create_client
+from .llm import LLMClient, create_client, LLMAuthenticationError
 from .web import extract_clean_text, html_to_markdown
 
 
@@ -68,13 +68,12 @@ async def stream_view(
         if buffer:
             yield buffer
 
+    except LLMAuthenticationError as e:
+        # Handle authentication errors with user-friendly message
+        yield f"## 🔐 Authentication Error\n\n{str(e)}\n\n**Quick Setup:**\n\n1. Create a `.env` file in your project directory\n2. Add your API key: `SPEGEL_API_KEY=your_api_key_here`\n3. Or set provider-specific keys like `OPENAI_API_KEY=your_key`\n4. Restart the application"
     except RuntimeError as e:
-        # Handle authentication errors and other RuntimeErrors with user-friendly messages
-        error_message = str(e)
-        if "Authentication failed" in error_message:
-            yield f"## 🔐 Authentication Error\n\n{error_message}\n\n**Quick Setup:**\n\n1. Create a `.env` file in your project directory\n2. Add your API key: `SPEGEL_API_KEY=your_api_key_here`\n3. Or set provider-specific keys like `OPENAI_API_KEY=your_key`\n4. Restart the application"
-        else:
-            yield f"## ❌ Error\n\n{error_message}"
+        # Handle other RuntimeErrors
+        yield f"## ❌ Error\n\n{str(e)}"
     except Exception as e:
         # Handle other unexpected errors
         yield f"## ❌ Unexpected Error\n\n{str(e)}"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -18,13 +18,6 @@ def mock_litellm():
         yield mock_litellm
 
 
-def test_create_client_with_specific_model(mock_litellm):
-    """When specific model is provided, should return LiteLLMClient with that model."""
-    client = create_client("gpt-4o-mini")
-    assert isinstance(client, LiteLLMClient)
-    assert client.model == "gpt-4o-mini"
-
-
 def test_create_client_no_api_key():
     """When no API key is set, should return None client."""
     with patch.dict(os.environ, {}, clear=True):
@@ -33,6 +26,13 @@ def test_create_client_no_api_key():
             with patch("spegel.llm.LiteLLMClient", side_effect=Exception("No API key")):
                 client = create_client("test-model")
                 assert client is None
+
+
+def test_create_client_with_specific_model(mock_litellm):
+    """When specific model is provided, should return LiteLLMClient with that model."""
+    client = create_client("gpt-4o-mini")
+    assert isinstance(client, LiteLLMClient)
+    assert client.model == "gpt-4o-mini"
 
 
 def test_create_client_with_custom_model():

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -18,6 +18,13 @@ def mock_litellm():
         yield mock_litellm
 
 
+def test_create_client_with_specific_model(mock_litellm):
+    """When specific model is provided, should return LiteLLMClient with that model."""
+    client = create_client("gpt-4o-mini")
+    assert isinstance(client, LiteLLMClient)
+    assert client.model == "gpt-4o-mini"
+
+
 def test_create_client_no_api_key():
     """When no API key is set, should return None client."""
     with patch.dict(os.environ, {}, clear=True):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,168 +1,320 @@
-from unittest.mock import Mock
-
 import pytest
+from unittest.mock import Mock, AsyncMock, patch
 
+from spegel.views import stream_view, _get_view_llm_client
 from spegel.config import View
-from spegel.views import stream_view
-
-SAMPLE_HTML = """
-<html>
-<head><title>Test Page</title></head>
-<body>
-    <h1>Main Title</h1>
-    <p>This is a test paragraph with <a href="https://example.com">a link</a>.</p>
-    <div>Some content in a div.</div>
-</body>
-</html>
-"""
 
 
 class TestStreamView:
     """Test the stream_view function."""
 
     @pytest.mark.asyncio
-    async def test_stream_raw_view(self):
-        """Raw view should yield complete markdown immediately."""
-        view = View(id="raw", name="Raw", hotkey="r", prompt="")
+    async def test_stream_view_raw(self):
+        """Test streaming raw HTML view."""
+        view = View(id="raw", name="Raw", hotkey="1", description="Raw HTML", prompt="")
+        raw_html = "<html><body>Test</body></html>"
 
-        chunks = []
-        async for chunk in stream_view(view, SAMPLE_HTML, None, "https://test.com"):
-            chunks.append(chunk)
+        # Mock html_to_markdown
+        with patch("spegel.views.html_to_markdown") as mock_html_to_markdown:
+            mock_html_to_markdown.return_value = "# Test Content"
 
-        # Should get one complete chunk
-        assert len(chunks) == 1
-        result = chunks[0]
-        assert "# Test Page" in result
-        assert "[a link](https://example.com)" in result
+            chunks = []
+            async for chunk in stream_view(view, raw_html, None, "http://test.com"):
+                chunks.append(chunk)
+
+            assert chunks == ["# Test Content"]
+            mock_html_to_markdown.assert_called_once_with(raw_html, "http://test.com")
 
     @pytest.mark.asyncio
-    async def test_stream_view_no_llm(self):
-        """Non-raw view without LLM should yield error message."""
-        view = View(id="summary", name="Summary", hotkey="s", prompt="Summarize this")
+    async def test_stream_view_no_client(self):
+        """Test streaming when no LLM client is available."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+        )
+        raw_html = "<html><body>Test</body></html>"
 
         chunks = []
-        async for chunk in stream_view(view, SAMPLE_HTML, None, "https://test.com"):
+        async for chunk in stream_view(view, raw_html, None, "http://test.com"):
             chunks.append(chunk)
 
         assert len(chunks) == 1
         assert "LLM not available" in chunks[0]
+        assert "OPENAI_API_KEY" in chunks[0]
 
     @pytest.mark.asyncio
-    async def test_stream_view_with_llm(self):
-        """Non-raw view with LLM should yield chunks as they arrive."""
-        view = View(id="summary", name="Summary", hotkey="s", prompt="Summarize this")
-
-        # Mock LLM client that yields chunks with newlines
-        mock_client = Mock()
-
-        async def mock_stream(prompt, content):
-            yield "First line\n"
-            yield "Second line\n"
-            yield "Partial"
-            yield " line\n"
-            yield "Final chunk"
-
-        mock_client.stream = mock_stream
-
-        chunks = []
-        async for chunk in stream_view(
-            view, SAMPLE_HTML, mock_client, "https://test.com"
-        ):
-            chunks.append(chunk)
-
-        # Should yield complete lines plus final buffer
-        expected_chunks = [
-            "First line\n",
-            "Second line\n",
-            "Partial line\n",
-            "Final chunk",
-        ]
-        assert chunks == expected_chunks
-
-    @pytest.mark.asyncio
-    async def test_stream_view_line_buffering(self):
-        """Stream view should buffer partial lines correctly."""
-        view = View(id="test", name="Test", hotkey="t", prompt="Test prompt")
-
-        mock_client = Mock()
-
-        async def mock_stream(prompt, content):
-            # Simulate chunks that don't align with line boundaries
-            yield "Start of"
-            yield " first line\nSecond"
-            yield " line\nThird line\nPartial"
-
-        mock_client.stream = mock_stream
-
-        chunks = []
-        async for chunk in stream_view(
-            view, SAMPLE_HTML, mock_client, "https://test.com"
-        ):
-            chunks.append(chunk)
-
-        expected = [
-            "Start of first line\n",
-            "Second line\n",
-            "Third line\n",
-            "Partial",  # Final buffer without newline
-        ]
-        assert chunks == expected
-
-    @pytest.mark.asyncio
-    async def test_stream_view_empty_chunks(self):
-        """Stream view should handle empty chunks gracefully."""
-        view = View(id="test", name="Test", hotkey="t", prompt="Test prompt")
-
-        mock_client = Mock()
-
-        async def mock_stream(prompt, content):
-            yield ""
-            yield "Real content\n"
-            yield ""
-            yield "More content"
-            yield ""
-
-        mock_client.stream = mock_stream
-
-        chunks = []
-        async for chunk in stream_view(
-            view, SAMPLE_HTML, mock_client, "https://test.com"
-        ):
-            chunks.append(chunk)
-
-        # Empty chunks should be skipped
-        assert chunks == ["Real content\n", "More content"]
-
-
-class TestViewIntegration:
-    """Integration tests for view processing."""
-
-    @pytest.mark.asyncio
-    async def test_view_prompt_construction(self):
-        """Test that view prompt is properly combined with content."""
+    async def test_stream_view_with_client(self):
+        """Test streaming with a working LLM client."""
         view = View(
-            id="test", name="Test", hotkey="t", prompt="Please analyze this webpage:"
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
         )
+        raw_html = "<html><body>Test content</body></html>"
 
-        mock_client = Mock()
-        received_prompts = []
+        # Mock client
+        mock_client = AsyncMock()
 
+        # Mock the stream method to return chunks
         async def mock_stream(prompt, content):
-            received_prompts.append(prompt)
-            yield "Analysis complete"
+            yield "This is a "
+            yield "test response\n"
+            yield "with multiple chunks"
 
         mock_client.stream = mock_stream
 
-        chunks = []
-        async for chunk in stream_view(
-            view, SAMPLE_HTML, mock_client, "https://test.com"
-        ):
-            chunks.append(chunk)
+        # Mock extract_clean_text
+        with patch("spegel.views.extract_clean_text") as mock_extract:
+            mock_extract.return_value = "Clean text content"
 
-        # Should have received the combined prompt
-        assert len(received_prompts) == 1
-        full_prompt = received_prompts[0]
-        assert "Please analyze this webpage:" in full_prompt
-        assert "Webpage content:" in full_prompt
-        assert "Main Title" in full_prompt  # Content from cleaned HTML
-        assert chunks == ["Analysis complete"]
+            chunks = []
+            async for chunk in stream_view(
+                view, raw_html, mock_client, "http://test.com"
+            ):
+                chunks.append(chunk)
+
+            # Should get all chunks
+            assert "This is a test response\n" in "".join(chunks)
+            assert "with multiple chunks" in "".join(chunks)
+
+    @pytest.mark.asyncio
+    async def test_stream_view_authentication_error(self):
+        """Test streaming with authentication error."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+        )
+        raw_html = "<html><body>Test content</body></html>"
+
+        # Mock client that raises authentication error
+        mock_client = AsyncMock()
+
+        async def mock_stream_with_auth_error(prompt, content):
+            raise RuntimeError(
+                "Authentication failed for model 'openai/gpt-4'. Please set a valid API key for openai."
+            )
+            yield  # Make it an async generator (unreachable)
+
+        mock_client.stream = mock_stream_with_auth_error
+
+        # Mock extract_clean_text
+        with patch("spegel.views.extract_clean_text") as mock_extract:
+            mock_extract.return_value = "Clean text content"
+
+            chunks = []
+            async for chunk in stream_view(
+                view, raw_html, mock_client, "http://test.com"
+            ):
+                chunks.append(chunk)
+
+            # Should get authentication error message
+            assert len(chunks) == 1
+            error_content = chunks[0]
+            assert "🔐 Authentication Error" in error_content
+            assert "Authentication failed for model 'openai/gpt-4'" in error_content
+            assert "Quick Setup:" in error_content
+            assert "Create a `.env` file" in error_content
+            assert "SPEGEL_API_KEY=your_api_key_here" in error_content
+
+    @pytest.mark.asyncio
+    async def test_stream_view_general_runtime_error(self):
+        """Test streaming with general runtime error."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+        )
+        raw_html = "<html><body>Test content</body></html>"
+
+        # Mock client that raises general runtime error
+        mock_client = AsyncMock()
+
+        async def mock_stream_with_error(prompt, content):
+            raise RuntimeError("Some general error occurred")
+            yield  # Make it an async generator (unreachable)
+
+        mock_client.stream = mock_stream_with_error
+
+        # Mock extract_clean_text
+        with patch("spegel.views.extract_clean_text") as mock_extract:
+            mock_extract.return_value = "Clean text content"
+
+            chunks = []
+            async for chunk in stream_view(
+                view, raw_html, mock_client, "http://test.com"
+            ):
+                chunks.append(chunk)
+
+            # Should get general error message
+            assert len(chunks) == 1
+            error_content = chunks[0]
+            assert "❌ Error" in error_content
+            assert "Some general error occurred" in error_content
+
+    @pytest.mark.asyncio
+    async def test_stream_view_unexpected_error(self):
+        """Test streaming with unexpected error."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+        )
+        raw_html = "<html><body>Test content</body></html>"
+
+        # Mock client that raises unexpected error
+        mock_client = AsyncMock()
+
+        async def mock_stream_with_unexpected_error(prompt, content):
+            raise ValueError("Unexpected error type")
+            yield  # Make it an async generator (unreachable)
+
+        mock_client.stream = mock_stream_with_unexpected_error
+
+        # Mock extract_clean_text
+        with patch("spegel.views.extract_clean_text") as mock_extract:
+            mock_extract.return_value = "Clean text content"
+
+            chunks = []
+            async for chunk in stream_view(
+                view, raw_html, mock_client, "http://test.com"
+            ):
+                chunks.append(chunk)
+
+            # Should get unexpected error message
+            assert len(chunks) == 1
+            error_content = chunks[0]
+            assert "❌ Unexpected Error" in error_content
+            assert "Unexpected error type" in error_content
+
+    @pytest.mark.asyncio
+    async def test_stream_view_with_buffering(self):
+        """Test streaming with content that requires buffering."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+        )
+        raw_html = "<html><body>Test content</body></html>"
+
+        # Mock client
+        mock_client = AsyncMock()
+
+        # Mock the stream method to return chunks with and without newlines
+        async def mock_stream(prompt, content):
+            yield "Line 1\nLine 2\n"
+            yield "Line 3"
+            yield "\nLine 4"
+            yield " remaining"
+
+        mock_client.stream = mock_stream
+
+        # Mock extract_clean_text
+        with patch("spegel.views.extract_clean_text") as mock_extract:
+            mock_extract.return_value = "Clean text content"
+
+            chunks = []
+            async for chunk in stream_view(
+                view, raw_html, mock_client, "http://test.com"
+            ):
+                chunks.append(chunk)
+
+            # Should properly handle buffering
+            result = "".join(chunks)
+            assert "Line 1\n" in result
+            assert "Line 2\n" in result
+            assert "Line 3\n" in result
+            assert "Line 4 remaining" in result
+
+
+class TestGetViewLLMClient:
+    """Test the _get_view_llm_client function."""
+
+    def test_get_view_llm_client_no_model_override(self):
+        """Test getting client when view has no model override."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+        )
+        default_client = Mock()
+
+        result = _get_view_llm_client(view, default_client)
+
+        assert result == default_client
+
+    def test_get_view_llm_client_with_model_override(self):
+        """Test getting client when view has model override."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+            model="gpt-4",
+        )
+        default_client = Mock()
+
+        with patch("spegel.views.create_client") as mock_create_client:
+            mock_view_client = Mock()
+            mock_create_client.return_value = mock_view_client
+
+            result = _get_view_llm_client(view, default_client)
+
+            assert result == mock_view_client
+            mock_create_client.assert_called_once_with(model="gpt-4")
+
+    def test_get_view_llm_client_with_model_override_fails(self):
+        """Test getting client when view model override fails."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+            model="invalid-model",
+        )
+        default_client = Mock()
+
+        with patch("spegel.views.create_client") as mock_create_client:
+            mock_create_client.return_value = None  # Simulate failure
+
+            result = _get_view_llm_client(view, default_client)
+
+            # Should fall back to default client
+            assert result == default_client
+            mock_create_client.assert_called_once_with(model="invalid-model")
+
+    def test_get_view_llm_client_with_empty_model_override(self):
+        """Test getting client when view has empty model override."""
+        view = View(
+            id="summary",
+            name="Summary",
+            hotkey="2",
+            description="Summary view",
+            prompt="Summarize this",
+            model="  ",
+        )
+        default_client = Mock()
+
+        with patch("spegel.views.create_client") as mock_create_client:
+            result = _get_view_llm_client(view, default_client)
+
+            # Should not call create_client for empty model
+            assert result == default_client
+            mock_create_client.assert_not_called()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,323 +1,168 @@
-import pytest
-from unittest.mock import Mock, AsyncMock, patch
+from unittest.mock import Mock
 
-from spegel.views import stream_view, _get_view_llm_client
+import pytest
+
 from spegel.config import View
-from spegel.llm import LLMAuthenticationError
+from spegel.views import stream_view
+
+SAMPLE_HTML = """
+<html>
+<head><title>Test Page</title></head>
+<body>
+    <h1>Main Title</h1>
+    <p>This is a test paragraph with <a href="https://example.com">a link</a>.</p>
+    <div>Some content in a div.</div>
+</body>
+</html>
+"""
 
 
 class TestStreamView:
     """Test the stream_view function."""
 
     @pytest.mark.asyncio
-    async def test_stream_view_raw(self):
-        """Test streaming raw HTML view."""
-        view = View(id="raw", name="Raw", hotkey="1", description="Raw HTML", prompt="")
-        raw_html = "<html><body>Test</body></html>"
-
-        # Mock html_to_markdown
-        with patch("spegel.views.html_to_markdown") as mock_html_to_markdown:
-            mock_html_to_markdown.return_value = "# Test Content"
-
-            chunks = []
-            async for chunk in stream_view(view, raw_html, None, "http://test.com"):
-                chunks.append(chunk)
-
-            assert chunks == ["# Test Content"]
-            mock_html_to_markdown.assert_called_once_with(raw_html, "http://test.com")
-
-    @pytest.mark.asyncio
-    async def test_stream_view_no_client(self):
-        """Test streaming when no LLM client is available."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-        )
-        raw_html = "<html><body>Test</body></html>"
+    async def test_stream_raw_view(self):
+        """Raw view should yield complete markdown immediately."""
+        view = View(id="raw", name="Raw", hotkey="r", prompt="")
 
         chunks = []
-        async for chunk in stream_view(view, raw_html, None, "http://test.com"):
+        async for chunk in stream_view(view, SAMPLE_HTML, None, "https://test.com"):
+            chunks.append(chunk)
+
+        # Should get one complete chunk
+        assert len(chunks) == 1
+        result = chunks[0]
+        assert "# Test Page" in result
+        assert "[a link](https://example.com)" in result
+
+    @pytest.mark.asyncio
+    async def test_stream_view_no_llm(self):
+        """Non-raw view without LLM should yield error message."""
+        view = View(id="summary", name="Summary", hotkey="s", prompt="Summarize this")
+
+        chunks = []
+        async for chunk in stream_view(view, SAMPLE_HTML, None, "https://test.com"):
             chunks.append(chunk)
 
         assert len(chunks) == 1
         assert "LLM not available" in chunks[0]
-        assert "OPENAI_API_KEY" in chunks[0]
 
     @pytest.mark.asyncio
-    async def test_stream_view_with_client(self):
-        """Test streaming with a working LLM client."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-        )
-        raw_html = "<html><body>Test content</body></html>"
+    async def test_stream_view_with_llm(self):
+        """Non-raw view with LLM should yield chunks as they arrive."""
+        view = View(id="summary", name="Summary", hotkey="s", prompt="Summarize this")
 
-        # Mock client
-        mock_client = AsyncMock()
+        # Mock LLM client that yields chunks with newlines
+        mock_client = Mock()
 
-        # Mock the stream method to return chunks
         async def mock_stream(prompt, content):
-            yield "This is a "
-            yield "test response\n"
-            yield "with multiple chunks"
+            yield "First line\n"
+            yield "Second line\n"
+            yield "Partial"
+            yield " line\n"
+            yield "Final chunk"
 
         mock_client.stream = mock_stream
 
-        # Mock extract_clean_text
-        with patch("spegel.views.extract_clean_text") as mock_extract:
-            mock_extract.return_value = "Clean text content"
+        chunks = []
+        async for chunk in stream_view(
+            view, SAMPLE_HTML, mock_client, "https://test.com"
+        ):
+            chunks.append(chunk)
 
-            chunks = []
-            async for chunk in stream_view(
-                view, raw_html, mock_client, "http://test.com"
-            ):
-                chunks.append(chunk)
-
-            # Should get all chunks
-            assert "This is a test response\n" in "".join(chunks)
-            assert "with multiple chunks" in "".join(chunks)
-
-    @pytest.mark.asyncio
-    async def test_stream_view_authentication_error(self):
-        """Test streaming with authentication error."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-        )
-        raw_html = "<html><body>Test content</body></html>"
-
-        # Mock client that raises authentication error
-        mock_client = AsyncMock()
-
-        # Create mock original error
-        mock_original_error = Exception("API key not valid")
-
-        async def mock_stream_with_auth_error(prompt, content):
-            raise LLMAuthenticationError("openai/gpt-4", "openai", mock_original_error)
-            yield  # Make it an async generator (unreachable)
-
-        mock_client.stream = mock_stream_with_auth_error
-
-        # Mock extract_clean_text
-        with patch("spegel.views.extract_clean_text") as mock_extract:
-            mock_extract.return_value = "Clean text content"
-
-            chunks = []
-            async for chunk in stream_view(
-                view, raw_html, mock_client, "http://test.com"
-            ):
-                chunks.append(chunk)
-
-            # Should get authentication error message
-            assert len(chunks) == 1
-            error_content = chunks[0]
-            assert "🔐 Authentication Error" in error_content
-            assert "Authentication failed for model 'openai/gpt-4'" in error_content
-            assert "Please set a valid API key for openai" in error_content
-            assert "Quick Setup:" in error_content
-            assert "Create a `.env` file" in error_content
-            assert "SPEGEL_API_KEY=your_api_key_here" in error_content
+        # Should yield complete lines plus final buffer
+        expected_chunks = [
+            "First line\n",
+            "Second line\n",
+            "Partial line\n",
+            "Final chunk",
+        ]
+        assert chunks == expected_chunks
 
     @pytest.mark.asyncio
-    async def test_stream_view_general_runtime_error(self):
-        """Test streaming with general runtime error."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-        )
-        raw_html = "<html><body>Test content</body></html>"
+    async def test_stream_view_line_buffering(self):
+        """Stream view should buffer partial lines correctly."""
+        view = View(id="test", name="Test", hotkey="t", prompt="Test prompt")
 
-        # Mock client that raises general runtime error
-        mock_client = AsyncMock()
+        mock_client = Mock()
 
-        async def mock_stream_with_error(prompt, content):
-            raise RuntimeError("Some general error occurred")
-            yield  # Make it an async generator (unreachable)
-
-        mock_client.stream = mock_stream_with_error
-
-        # Mock extract_clean_text
-        with patch("spegel.views.extract_clean_text") as mock_extract:
-            mock_extract.return_value = "Clean text content"
-
-            chunks = []
-            async for chunk in stream_view(
-                view, raw_html, mock_client, "http://test.com"
-            ):
-                chunks.append(chunk)
-
-            # Should get general error message
-            assert len(chunks) == 1
-            error_content = chunks[0]
-            assert "❌ Error" in error_content
-            assert "Some general error occurred" in error_content
-
-    @pytest.mark.asyncio
-    async def test_stream_view_unexpected_error(self):
-        """Test streaming with unexpected error."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-        )
-        raw_html = "<html><body>Test content</body></html>"
-
-        # Mock client that raises unexpected error
-        mock_client = AsyncMock()
-
-        async def mock_stream_with_unexpected_error(prompt, content):
-            raise ValueError("Unexpected error type")
-            yield  # Make it an async generator (unreachable)
-
-        mock_client.stream = mock_stream_with_unexpected_error
-
-        # Mock extract_clean_text
-        with patch("spegel.views.extract_clean_text") as mock_extract:
-            mock_extract.return_value = "Clean text content"
-
-            chunks = []
-            async for chunk in stream_view(
-                view, raw_html, mock_client, "http://test.com"
-            ):
-                chunks.append(chunk)
-
-            # Should get unexpected error message
-            assert len(chunks) == 1
-            error_content = chunks[0]
-            assert "❌ Unexpected Error" in error_content
-            assert "Unexpected error type" in error_content
-
-    @pytest.mark.asyncio
-    async def test_stream_view_with_buffering(self):
-        """Test streaming with content that requires buffering."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-        )
-        raw_html = "<html><body>Test content</body></html>"
-
-        # Mock client
-        mock_client = AsyncMock()
-
-        # Mock the stream method to return chunks with and without newlines
         async def mock_stream(prompt, content):
-            yield "Line 1\nLine 2\n"
-            yield "Line 3"
-            yield "\nLine 4"
-            yield " remaining"
+            # Simulate chunks that don't align with line boundaries
+            yield "Start of"
+            yield " first line\nSecond"
+            yield " line\nThird line\nPartial"
 
         mock_client.stream = mock_stream
 
-        # Mock extract_clean_text
-        with patch("spegel.views.extract_clean_text") as mock_extract:
-            mock_extract.return_value = "Clean text content"
+        chunks = []
+        async for chunk in stream_view(
+            view, SAMPLE_HTML, mock_client, "https://test.com"
+        ):
+            chunks.append(chunk)
 
-            chunks = []
-            async for chunk in stream_view(
-                view, raw_html, mock_client, "http://test.com"
-            ):
-                chunks.append(chunk)
+        expected = [
+            "Start of first line\n",
+            "Second line\n",
+            "Third line\n",
+            "Partial",  # Final buffer without newline
+        ]
+        assert chunks == expected
 
-            # Should properly handle buffering
-            result = "".join(chunks)
-            assert "Line 1\n" in result
-            assert "Line 2\n" in result
-            assert "Line 3\n" in result
-            assert "Line 4 remaining" in result
+    @pytest.mark.asyncio
+    async def test_stream_view_empty_chunks(self):
+        """Stream view should handle empty chunks gracefully."""
+        view = View(id="test", name="Test", hotkey="t", prompt="Test prompt")
+
+        mock_client = Mock()
+
+        async def mock_stream(prompt, content):
+            yield ""
+            yield "Real content\n"
+            yield ""
+            yield "More content"
+            yield ""
+
+        mock_client.stream = mock_stream
+
+        chunks = []
+        async for chunk in stream_view(
+            view, SAMPLE_HTML, mock_client, "https://test.com"
+        ):
+            chunks.append(chunk)
+
+        # Empty chunks should be skipped
+        assert chunks == ["Real content\n", "More content"]
 
 
-class TestGetViewLLMClient:
-    """Test the _get_view_llm_client function."""
+class TestViewIntegration:
+    """Integration tests for view processing."""
 
-    def test_get_view_llm_client_no_model_override(self):
-        """Test getting client when view has no model override."""
+    @pytest.mark.asyncio
+    async def test_view_prompt_construction(self):
+        """Test that view prompt is properly combined with content."""
         view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
+            id="test", name="Test", hotkey="t", prompt="Please analyze this webpage:"
         )
-        default_client = Mock()
 
-        result = _get_view_llm_client(view, default_client)
+        mock_client = Mock()
+        received_prompts = []
 
-        assert result == default_client
+        async def mock_stream(prompt, content):
+            received_prompts.append(prompt)
+            yield "Analysis complete"
 
-    def test_get_view_llm_client_with_model_override(self):
-        """Test getting client when view has model override."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-            model="gpt-4",
-        )
-        default_client = Mock()
+        mock_client.stream = mock_stream
 
-        with patch("spegel.views.create_client") as mock_create_client:
-            mock_view_client = Mock()
-            mock_create_client.return_value = mock_view_client
+        chunks = []
+        async for chunk in stream_view(
+            view, SAMPLE_HTML, mock_client, "https://test.com"
+        ):
+            chunks.append(chunk)
 
-            result = _get_view_llm_client(view, default_client)
-
-            assert result == mock_view_client
-            mock_create_client.assert_called_once_with(model="gpt-4")
-
-    def test_get_view_llm_client_with_model_override_fails(self):
-        """Test getting client when view model override fails."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-            model="invalid-model",
-        )
-        default_client = Mock()
-
-        with patch("spegel.views.create_client") as mock_create_client:
-            mock_create_client.return_value = None  # Simulate failure
-
-            result = _get_view_llm_client(view, default_client)
-
-            # Should fall back to default client
-            assert result == default_client
-            mock_create_client.assert_called_once_with(model="invalid-model")
-
-    def test_get_view_llm_client_with_empty_model_override(self):
-        """Test getting client when view has empty model override."""
-        view = View(
-            id="summary",
-            name="Summary",
-            hotkey="2",
-            description="Summary view",
-            prompt="Summarize this",
-            model="  ",
-        )
-        default_client = Mock()
-
-        with patch("spegel.views.create_client") as mock_create_client:
-            result = _get_view_llm_client(view, default_client)
-
-            # Should not call create_client for empty model
-            assert result == default_client
-            mock_create_client.assert_not_called()
+        # Should have received the combined prompt
+        assert len(received_prompts) == 1
+        full_prompt = received_prompts[0]
+        assert "Please analyze this webpage:" in full_prompt
+        assert "Webpage content:" in full_prompt
+        assert "Main Title" in full_prompt  # Content from cleaned HTML
+        assert chunks == ["Analysis complete"]

--- a/uv.lock
+++ b/uv.lock
@@ -1307,7 +1307,7 @@ wheels = [
 
 [[package]]
 name = "spegel"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
```
GEMINI_API_KEY=foo spegel news.ycombinator.com
```
now gives this much nicer error message
<img width="1409" height="191" alt="image" src="https://github.com/user-attachments/assets/f89581c9-cc89-4ab6-a057-d944c0674705" />
